### PR TITLE
Uses client credential instead of refresh token

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ skills:
     package_name: snipsmopidy
     params:
       mopidy_host: <MOPIDY_IP> # defaults to localhost
-      spotify_refresh_token: <SPOTIFY_REFRESH_TOKEN>
       spotify_client_id: <SPOTIFY_CLIENT_ID>
       spotify_client_secret: <SPOTIFY_CLIENT_SECRET>
 ~~~
@@ -96,12 +95,9 @@ The skill allows you to control [Mopidy](http://musicpartners.Mopidy.com/docs?q=
 ~~~python
 from snipsmopidy.snipsmopidy import SnipsMopidy
 
-Mopidy = SnipsMopidy(SPOTIFY_REFRESH_TOKEN, SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET)
+Mopidy = SnipsMopidy(SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET)
 Mopidy.play_artist("John Coltrane")
 ~~~
-
-The `SPOTIFY_REFRESH_TOKEN` is used for playing music from Spotify. You can obtain it from the [Snips Spotify Login](https://snips-spotify-login.herokuapp.com) page.
-
 
 ## Contributing
 

--- a/snipsmopidy/Snipsspec
+++ b/snipsmopidy/Snipsspec
@@ -3,7 +3,6 @@ class_name: SnipsMopidy
 description: Mopidy skill for Snips
 params:
   mopidy_host: YOUR_MOPIDY_IP
-  spotify_refresh_token: YOUR_SPOTIFY_REFRESH_TOKEN
   spotify_client_id: YOUR_SPOTIFY_CLIENT_ID
   spotify_client_secret: YOUR_SPOTIFY_CLIENT_SECRET
 notifications:

--- a/snipsmopidy/snipsmopidy.py
+++ b/snipsmopidy/snipsmopidy.py
@@ -19,7 +19,7 @@ class SnipsMopidy:
     :param mopidy_host: The hostname of the Mopidy player
     """
 
-    def __init__(self, spotify_refresh_token=None, spotify_client_id=None, spotify_client_secret=None,
+    def __init__(self, spotify_client_id=None, spotify_client_secret=None,
                  mopidy_host='127.0.0.1', locale=None):
         self.host = mopidy_host
         connexion_established = False
@@ -38,8 +38,7 @@ class SnipsMopidy:
         status = self.client.status()
         self.previous_volume = int(status.get('volume'))
         self.max_volume = MAX_VOLUME
-        if spotify_refresh_token is not None:
-            self.spotify = SpotifyClient(spotify_refresh_token, spotify_client_id, spotify_client_secret)
+        self.spotify = SpotifyClient(spotify_client_id, spotify_client_secret)
 
     def pause(self):
         self.client.pause(1)

--- a/snipsmopidy/spotify.py
+++ b/snipsmopidy/spotify.py
@@ -7,10 +7,9 @@ import requests
 
 class SpotifyClient():
 
-    def __init__(self, spotify_refresh_token, client_id, client_secret):
+    def __init__(self, client_id, client_secret):
         self.client_id = client_id
         self.client_secret = client_secret
-        self.refresh_token = spotify_refresh_token
         self.get_user_playlists()
         self.get_user_id()
 
@@ -18,11 +17,9 @@ class SpotifyClient():
         _r = requests.post(
             "https://accounts.spotify.com/api/token",
             data={
-                "client_id": self.client_id,
-                "client_secret": self.client_secret,
-                "grant_type": "refresh_token",
-                "refresh_token": self.refresh_token
-            })
+                "grant_type": "client_credentials",
+            },
+            auth=(self.client_id, self.client_secret))
         if 'access_token' in _r.json():
             self.access_token = _r.json()['access_token']
         else:


### PR DESCRIPTION
As the user already provide client_id and client_secret, there is no need to use refresh token to get access token. We can just use client_credential provide by Spotify to get the access token.

ref: https://beta.developer.spotify.com/documentation/general/guides/authorization-guide/#client-credentials-flow